### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to
 
 ## [Unreleased]
 
-## 2.0.2 - 2022-11-01
+## 2.0.3 - 2022-11-01
 
 ### Added
 


### PR DESCRIPTION
Failed to release because tag 2.0.2 already existed.